### PR TITLE
add .test dev domain to wp-config for newest chrome and safari dev

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -50,6 +50,13 @@ switch ( $_SERVER[ 'SERVER_NAME' ] ) {
         define( 'WP_CONTENT_BASE_URL', 'http://partio.cdn.geniem.com' );
         define( 'WP_ADMIN_URL', 'http://admin.partio.geniem.com' );
         break;
+    case 'partio-ohjelma.test': // LOCAL DEV DOMAIN
+        define( 'WP_HOME', 'http://partio-ohjelma.test' );
+        define( 'WP_SITEURL', 'http://partio-ohjelma.test/wp/' );
+        define( 'WP_PUB_SITEURL', 'http://partio-ohjelma.test' );
+        define( 'WP_CONTENT_BASE_URL', 'http://partio-ohjelma.test' );
+        define( 'WP_ADMIN_URL', 'http://partio-ohjelma.test' );
+        break;        
     case 'partio-ohjelma.dev': // LOCAL DEV DOMAIN
         define( 'WP_HOME', 'http://partio-ohjelma.dev' );
         define( 'WP_SITEURL', 'http://partio-ohjelma.dev/wp/' );


### PR DESCRIPTION
since chrome version 63 and looks like also savari force .dev domains to https, add domain with .test also to config that there is options to develop site with different browsers.